### PR TITLE
Adding tests for BuildingPolygon

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="Mapsters" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,6 +9,7 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
@@ -24,6 +25,7 @@
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />

--- a/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonTests.java
@@ -1,0 +1,34 @@
+package delta.soen390.mapsters.BuildingTests;
+import android.test.InstrumentationTestCase;
+import com.google.android.gms.maps.model.LatLng;
+import java.util.ArrayList;
+import delta.soen390.mapsters.Geometry.BoundingBox2D;
+import delta.soen390.mapsters.Geometry.Vector2D;
+
+/**
+ * Created by Patrick on 15-02-22.
+ *
+ */
+
+public class BuildingPolygonTests extends InstrumentationTestCase {
+
+    private BoundingBox2D mBoundingBox2D;
+    private ArrayList<LatLng> mBoundingPoints;
+
+
+    public void testIsPointInsidePolygon() throws Exception {
+        mBoundingPoints = new ArrayList<>();
+        LatLng point1 = new LatLng(0,0);
+        LatLng point2 = new LatLng(0,2);
+        LatLng point3 = new LatLng(2,2);
+        LatLng point4 = new LatLng(2,0);
+        LatLng testPoint = new LatLng(1,1);
+        mBoundingPoints.add(point1);
+        mBoundingPoints.add(point2);
+        mBoundingPoints.add(point3);
+        mBoundingPoints.add(point4);
+        mBoundingBox2D = new BoundingBox2D(mBoundingPoints);
+        assertTrue(mBoundingBox2D.isPointInsideBoundingBox(new Vector2D(testPoint.latitude, testPoint.longitude)));
+    }
+
+}


### PR DESCRIPTION
Added BuildingPolygonTests. Only thing that can be tested is isPointInsidePolygon()  because the other methods require Polygon to be instantiate but it is a private method and it does not have its own getter
