### PR TITLE
Tests now extend AndroidTestCase instead of InstrumentionTestCase. Updated number of arguments for constructors for BuildingInfoTests and CalendarEventNotifications

### DIFF
--- a/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingInfoTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingInfoTests.java
@@ -1,6 +1,6 @@
 package delta.soen390.mapsters.BuildingTests;
 
-import android.test.InstrumentationTestCase;
+import android.test.AndroidTestCase;
 
 import delta.soen390.mapsters.Buildings.BuildingInfo;
 import com.google.android.gms.maps.model.LatLng;
@@ -11,16 +11,17 @@ import java.util.ArrayList;
  * Making sure getters all function correctly
  */
 
-public class BuildingInfoTests extends InstrumentationTestCase {
+public class BuildingInfoTests extends AndroidTestCase {
 
     private BuildingInfo mBuildingInfo;
     private String mBuildingCode;
     private String mBuildingName;
     private String mCampus;
     private String mImageUrl;
-    private String[] mBuildingServices;
     private LatLng mCoordinates;
     private ArrayList<LatLng> mBoundingCoordinates;
+    private ArrayList<String[]> mBuildingServices;
+    private ArrayList<String[]> mDepartments;
 
     @Override
     protected void setUp() throws Exception {
@@ -29,10 +30,12 @@ public class BuildingInfoTests extends InstrumentationTestCase {
         mBuildingName = "Airport terminal";
         mCampus = "SGW";
         mImageUrl = "http://concordia.ca";
-        mBuildingServices = new String[5];
         mCoordinates = new LatLng(0, 0);
         mBoundingCoordinates = new ArrayList<>();
-        mBuildingInfo = new BuildingInfo(mBuildingCode, mBuildingName, mCampus, mImageUrl, mBuildingServices,mCoordinates, mBoundingCoordinates);
+        mBuildingServices = new ArrayList<>(5);
+        mDepartments = new ArrayList<>(5);
+        mBuildingInfo = new BuildingInfo(mBuildingCode, mBuildingName, mCampus, mImageUrl,
+                mCoordinates, mBoundingCoordinates, mBuildingServices, mDepartments);
     }
 
     @Override
@@ -49,7 +52,6 @@ public class BuildingInfoTests extends InstrumentationTestCase {
     }
 
     public void testGetCampus() throws Exception {
-        BuildingInfoTests p = new BuildingInfoTests();
         assertEquals(mBuildingInfo.getCampus(), mCampus);
     }
 

--- a/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonManagerTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonManagerTests.java
@@ -1,6 +1,6 @@
 package delta.soen390.mapsters.BuildingTests;
 
-import android.test.InstrumentationTestCase;
+import android.test.AndroidTestCase;
 
 import com.google.android.gms.maps.model.LatLng;
 
@@ -11,7 +11,7 @@ import delta.soen390.mapsters.Buildings.BuildingPolygonManager;
  * Created by Patrick on 15-02-23.
  *
  */
-public class BuildingPolygonManagerTests extends InstrumentationTestCase {
+public class BuildingPolygonManagerTests extends AndroidTestCase {
 
     private BuildingPolygonManager mBuildingPolygonManager;
     private LatLng mLatLng;

--- a/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/BuildingPolygonTests.java
@@ -1,5 +1,5 @@
 package delta.soen390.mapsters.BuildingTests;
-import android.test.InstrumentationTestCase;
+import android.test.AndroidTestCase;
 import com.google.android.gms.maps.model.LatLng;
 import java.util.ArrayList;
 import delta.soen390.mapsters.Geometry.BoundingBox2D;
@@ -10,7 +10,7 @@ import delta.soen390.mapsters.Geometry.Vector2D;
  *
  */
 
-public class BuildingPolygonTests extends InstrumentationTestCase {
+public class BuildingPolygonTests extends AndroidTestCase {
 
     private BoundingBox2D mBoundingBox2D;
     private ArrayList<LatLng> mBoundingPoints;

--- a/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/PolygonSerializerTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/BuildingTests/PolygonSerializerTests.java
@@ -1,10 +1,9 @@
 package delta.soen390.mapsters.BuildingTests;
 
-import android.test.InstrumentationTestCase;
+import android.test.AndroidTestCase;
 
 import com.google.android.gms.maps.GoogleMap;
 
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 
@@ -15,7 +14,7 @@ import delta.soen390.mapsters.Buildings.PolygonSerializer;
  * Created by Patrick on 15-02-23.
  *
  */
-public class PolygonSerializerTests extends InstrumentationTestCase {
+public class PolygonSerializerTests extends AndroidTestCase {
 
     private PolygonSerializer mPolygonSerializer;
     private GoogleMap mGoogleMap;

--- a/app/src/androidTest/java/delta/soen390/mapsters/CalendarTests/CalendarEventNotificationTests.java
+++ b/app/src/androidTest/java/delta/soen390/mapsters/CalendarTests/CalendarEventNotificationTests.java
@@ -2,7 +2,6 @@ package delta.soen390.mapsters.CalendarTests;
 
 import android.content.ContentResolver;
 import android.test.AndroidTestCase;
-import android.test.mock.MockApplication;
 import android.test.mock.MockContentResolver;
 import android.test.mock.MockContext;
 
@@ -13,7 +12,9 @@ import delta.soen390.mapsters.Calendar.CalendarEvent;
 import delta.soen390.mapsters.Calendar.CalendarEventNotification;
 
 /**
+ *
  * Created by Felicia on 2015-02-25.
+ *
  */
 public class CalendarEventNotificationTests extends AndroidTestCase {
     private CalendarNotificationContext mMockContext;
@@ -25,7 +26,7 @@ public class CalendarEventNotificationTests extends AndroidTestCase {
     protected void setUp() throws Exception {
         mMockContext = new CalendarNotificationContext();
         mMapsActivity = new MapsActivity();
-        mCEvent = new CalendarEvent("H", "SGW", "Hall", new DateTime(1424877564), new DateTime(1424877564));
+        mCEvent = new CalendarEvent("H", "SGW", "Hall", new DateTime(1424877564), new DateTime(1424877564), new DateTime(1424877564));
         mCENotification = new CalendarEventNotification(mMockContext, mMapsActivity, mCEvent);
     }
 


### PR DESCRIPTION
Tests now extend AndroidTestCase instead of InstrumentionTestCase. Updated number of arguments for constructors for BuildingInfoTests and CalendarEventNotifications
